### PR TITLE
Migrate to import * as React from 'react'

### DIFF
--- a/react/src/DefaultRenderBlock.tsx
+++ b/react/src/DefaultRenderBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { RenderBlock } from './types'
 import EditorChildren from './EditorChildren'
 

--- a/react/src/Editor.tsx
+++ b/react/src/Editor.tsx
@@ -1,4 +1,5 @@
-import React, { useLayoutEffect, useRef, useState, useMemo } from 'react'
+import * as React from 'react';
+import { useLayoutEffect, useRef, useState, useMemo } from 'react'
 import {
   EditorState,
   setDomSelection,

--- a/react/src/EditorBlock.tsx
+++ b/react/src/EditorBlock.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { Block } from '@zettel/core'
 import EditorText from './EditorText'
 import { RenderProps } from './types'

--- a/react/src/EditorChildren.tsx
+++ b/react/src/EditorChildren.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { Block } from '@zettel/core'
 import EditorBlock from './EditorBlock'
 import { RenderProps } from './types'

--- a/react/src/EditorText.tsx
+++ b/react/src/EditorText.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { Block } from '@zettel/core'
 import { RenderProps } from './types'
 

--- a/site/src/components/Button/index.tsx
+++ b/site/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import styles from './index.module.css'
 
 type Props = {

--- a/site/src/examples/BlockStyling/index.tsx
+++ b/site/src/examples/BlockStyling/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState, getBlocksForRange } from '@zettel/core'
 import Editor from '@zettel/react'
 import { Button } from '../../components'

--- a/site/src/examples/Changes/index.tsx
+++ b/site/src/examples/Changes/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor from '@zettel/react'
 import styled from 'styled-components'

--- a/site/src/examples/Draggable/index.tsx
+++ b/site/src/examples/Draggable/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import Draggable from 'react-draggable';
 import { EditorState } from '@zettel/core'
 import Editor, { RenderBlock } from '@zettel/react'

--- a/site/src/examples/InputTester/index.tsx
+++ b/site/src/examples/InputTester/index.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState, useEffect } from 'react'
+import * as React from 'react';
+import { useRef, useState, useEffect } from 'react'
 
 const events = ['compositionstart', 'compositionupdate', 'input', 'beforeinput']
 

--- a/site/src/examples/ItalicAndBold/index.tsx
+++ b/site/src/examples/ItalicAndBold/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor from '@zettel/react'
 

--- a/site/src/examples/KittenAndLink/index.tsx
+++ b/site/src/examples/KittenAndLink/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor, { RenderBlock } from '@zettel/react'
 

--- a/site/src/examples/MarkdownTest/index.tsx
+++ b/site/src/examples/MarkdownTest/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor from '@zettel/react'
 

--- a/site/src/examples/Nocode/Cheat.tsx
+++ b/site/src/examples/Nocode/Cheat.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment, useState } from 'react'
+import * as React from 'react';
+import { Fragment, useState } from 'react'
 import { EditorState, getBlockForIndex } from '@zettel/core'
 import createPersistedState from 'use-persisted-state';
 import Editor from '@zettel/react'

--- a/site/src/examples/Nocode/StyleEditor.tsx
+++ b/site/src/examples/Nocode/StyleEditor.tsx
@@ -1,4 +1,5 @@
-import React, { Fragment, useState } from 'react'
+import * as React from 'react';
+import { Fragment, useState } from 'react'
 import styled from 'styled-components'
 
 type Props = {

--- a/site/src/examples/Nocode/index.tsx
+++ b/site/src/examples/Nocode/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { EditorState, getBlockForIndex } from '@zettel/core'
 import Editor from '@zettel/react'
 

--- a/site/src/examples/PlainText/index.tsx
+++ b/site/src/examples/PlainText/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor from '@zettel/react'
 

--- a/site/src/examples/Rtl/index.tsx
+++ b/site/src/examples/Rtl/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor from '@zettel/react'
 

--- a/site/src/examples/Table/index.tsx
+++ b/site/src/examples/Table/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor, { RenderBlock, EditorChildren, DefaultRenderBlock } from '@zettel/react'
 import './index.css'

--- a/site/src/examples/TimeTravel/Timeline.tsx
+++ b/site/src/examples/TimeTravel/Timeline.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { EditorState, undo, redo } from '@zettel/core'
 import './index.css'
 

--- a/site/src/examples/TimeTravel/index.tsx
+++ b/site/src/examples/TimeTravel/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor from '@zettel/react'
 import Timeline from './Timeline'

--- a/site/src/examples/Tree/index.tsx
+++ b/site/src/examples/Tree/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import { EditorState } from '@zettel/core'
 import Editor, { EditorChildren } from '@zettel/react'
 import './index.css'

--- a/site/src/examples/TypeStyler/index.tsx
+++ b/site/src/examples/TypeStyler/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import * as React from 'react';
+import { useState } from 'react'
 import Draggable from 'react-draggable';
 import { EditorState } from '@zettel/core'
 import Editor from '@zettel/react'

--- a/site/src/index.tsx
+++ b/site/src/index.tsx
@@ -1,6 +1,7 @@
 // @ts-ignore
 import {importMDX} from 'mdx.macro'
-import React, { useState, lazy, Suspense } from 'react';
+import * as React from 'react';
+import { useState, lazy, Suspense } from 'react';
 import { render, hydrate} from 'react-dom';
 import './index.css';
 import { createBrowserHistory } from 'history'

--- a/slides/components/Demo.jsx
+++ b/slides/components/Demo.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export default function Demo() {
   return <div>Hello</div>

--- a/slides/components/Diagram.jsx
+++ b/slides/components/Diagram.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import * as React from 'react'
 import { useSteps } from 'mdx-deck'
 
 export default props => {

--- a/slides/theme.js
+++ b/slides/theme.js
@@ -1,5 +1,5 @@
 // Example theme.js
-import React from 'react'
+import * as React from 'react'
 
 export default {
   fonts: {


### PR DESCRIPTION
Ref https://github.com/facebook/react/pull/18102

I used replace-in-files-cli to cover all cases
```
replace-in-files --string "import React from" --replacement "import * as React from" "**/*.{js,jsx,ts,tsx}"
replace-in-files --string "import React, {" --replacement "import * as React from 'react';\nimport {" "**/*.{js,jsx,ts,tsx}"
```